### PR TITLE
feat: Add support for routed IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ module "my_instance" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.3 |
-| <a name="requirement_scaleway"></a> [scaleway](#requirement_scaleway) | >= 2.2.0 |
+| <a name="requirement_scaleway"></a> [scaleway](#requirement_scaleway) | >= 2.28.0 |
 
 ## Resources
 
@@ -60,6 +60,7 @@ module "my_instance" {
 | <a name="input_private_networks"></a> [private_networks](#input_private_networks) | Private networks associated with the server. | `list(string)` | `[]` | no |
 | <a name="input_project_id"></a> [project_id](#input_project_id) | ID of the project the namespace is associated with. Ressource will be created in the project set at the provider level if null. | `string` | `null` | no |
 | <a name="input_root_volume"></a> [root_volume](#input_root_volume) | Root volume attached to the server on creation. Updates to `root_volume.size_in_gb` will be ignored after the creation of the server. | ```object({ delete_on_termination = bool size_in_gb = number volume_id = optional(string) volume_type = optional(string) })``` | `null` | no |
+| <a name="input_routed_ip_enabled"></a> [routed_ip_enabled](#input_routed_ip_enabled) | Determine if the instance will support routed ips only. Changing it to true will migrate the server and its IP to routed type. | `bool` | `false` | no |
 | <a name="input_security_group_id"></a> [security_group_id](#input_security_group_id) | ID of the security group the server is attached to. | `string` | `null` | no |
 | <a name="input_state"></a> [state](#input_state) | State of the server. Default to 'started'. Possible values are: 'started', 'stopped' or 'standby'. | `string` | `"started"` | no |
 | <a name="input_tags"></a> [tags](#input_tags) | Tags associated with the server and dedicated ip address. | `list(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ module "my_instance" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.3 |
 | <a name="requirement_scaleway"></a> [scaleway](#requirement_scaleway) | >= 2.2.0 |
 
 ## Resources

--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,7 @@ resource "scaleway_instance_server" "this" {
   enable_dynamic_ip = var.enable_public_ipv4
   enable_ipv6       = var.enable_ipv6
   ip_id             = var.enable_public_ipv4 == true ? scaleway_instance_ip.this[0].id : null
+  routed_ip_enabled = var.routed_ip_enabled
 
   dynamic "private_network" {
     for_each = toset(var.private_networks)

--- a/variables.tf
+++ b/variables.tf
@@ -73,6 +73,12 @@ variable "enable_public_ipv4" {
   default     = false
 }
 
+variable "routed_ip_enabled" {
+  type        = bool
+  description = "Determine if the instance will support routed ips only. Changing it to true will migrate the server and its IP to routed type."
+  default     = false
+}
+
 variable "private_networks" {
   type        = list(string)
   description = "Private networks associated with the server."

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     scaleway = {
       source  = "scaleway/scaleway"
-      version = ">= 2.2.0"
+      version = ">= 2.28.0"
     }
   }
 }


### PR DESCRIPTION
Add support for routed IP addresses. See Scaleway documentation regarding IP mobility for more information: <https://www.scaleway.com/en/blog/ip-mobility-removing-nat/>