### PR TITLE
Allow cloud-init configuration through user_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ module "my_instance" {
 | <a name="input_security_group_id"></a> [security_group_id](#input_security_group_id) | ID of the security group the server is attached to. | `string` | `null` | no |
 | <a name="input_state"></a> [state](#input_state) | State of the server. Default to 'started'. Possible values are: 'started', 'stopped' or 'standby'. | `string` | `"started"` | no |
 | <a name="input_tags"></a> [tags](#input_tags) | Tags associated with the server and dedicated ip address. | `list(string)` | `[]` | no |
+| <a name="input_user_data"></a> [user_data](#input_user_data) | User data associated with the server. Use the cloud-init key to use cloud-init on your instance. You can define values using: - string - UTF-8 encoded file content using file - Binary files using filebase64. | `any` | `null` | no |
 | <a name="input_zone"></a> [zone](#input_zone) | The zone in which the instance should be created. Ressource will be created in the zone set at the provider level if null. | `string` | `null` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "scaleway_instance_server" "this" {
   boot_type     = var.boot_type
   bootscript_id = var.bootscript_id
   state         = var.state
-  #  user_data     = var.user_data
+  user_data     = var.user_data
 
   project_id = var.project_id
   zone       = var.zone

--- a/variables.tf
+++ b/variables.tf
@@ -108,11 +108,11 @@ variable "state" {
   }
 }
 
-# variable "user_data" {
-#   type    = any
-#   description = "User data associated with the server. Use the cloud-init key to use cloud-init on your instance. You can define values using:\n- string\n- UTF-8 encoded file content using file\n- Binary files using filebase64."
-#   default = null
-# }
+variable "user_data" {
+  type        = any
+  description = "User data associated with the server. Use the cloud-init key to use cloud-init on your instance. You can define values using:\n- string\n- UTF-8 encoded file content using file\n- Binary files using filebase64."
+  default     = null
+}
 
 # Location & Tenancy
 variable "project_id" {


### PR DESCRIPTION
Hi !

It seems like the `user_data` attribute of the [`scaleway_instance_server`][scw-instance-tf] resource is not propagated.
This PR should bring back the expected behavior I found in the docs :pray:

[scw-instance-tf]: https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/instance_server#with-user-data-and-cloud-init

Thanks for the terraform module !

I just tried it locally on my project using the changes I included in my PR and it seems to work like a charm :)

Also is seems to reference #11 in some way ?

Closes #11 