### PR TITLE
Only create ipv4 domain record when enable_public_ipv4 is true

### DIFF
--- a/ipv4.tf
+++ b/ipv4.tf
@@ -48,7 +48,7 @@ data "scaleway_ipam_ip" "private_ipv4" {
 }
 
 resource "scaleway_domain_record" "ipv4" {
-  count = var.enable_public_ipv4 && (var.domainname != null) ? 1 : length(var.private_networks)
+  count = var.enable_public_ipv4 ? (var.domainname != null ? 1 : length(var.private_networks)) : 0
 
   data     = var.enable_public_ipv4 ? scaleway_instance_ip.public_ipv4[count.index].address : data.scaleway_ipam_ip.private_ipv4[count.index].address
   dns_zone = var.domainname


### PR DESCRIPTION
Given this Terraform configuration:
```terraform
module "vpc" {
  source  = "scaleway-terraform-modules/vpc/scaleway"
  version = "2.0.0"

  name = "my-cool-name"

  bastion_enabled = true
  enable_routing = true

  gw_enabled = true
  gw_reserve_ip = true
  gw_type = "VPC-GW-S"

  ipv4_subnet = "192.168.0.0/22"
}

module "gitlab-runner-instance" {
  source  = "scaleway-terraform-modules/instance/scaleway"
  version = "3.2.0"

  instance_type = "DEV1-L"
  image         = "debian_bookworm"

  hostname = "gitlab-runner-1"

  enable_ipv6        = false
  enable_public_ipv4 = false

  private_networks = [module.vpc.pn_id]

  root_volume = {
    size_in_gb   = 100
    volume_type = "sbs_volume"
    delete_on_termination = false
  }
}
```

You always get:
```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Missing required argument
│ 
│   with module.gitlab-runner-instance.scaleway_domain_record.ipv4[0],
│   on modules/terraform-scaleway-instance/ipv4.tf line 54, in resource "scaleway_domain_record" "ipv4":
│   54:   dns_zone = var.domainname
│ 
│ The argument "dns_zone" is required, but no definition was found.
╵
```

It seems if you use `private_networks`, it always tries to create the `scaleway_domain_record` regardless of the `enable_public_ipv4` variable. This has been fixed in this pull request.